### PR TITLE
Bug/exmaples test app

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,21 @@ const ipcBus = ipcBusModule.IpcBusClient.Create('/my-ipc-bus-path');
 ```
 
 ## Initialization in a Renderer process (either sandboxed or not)
+if use ***sandbox*** you have to preload code like this:
 ```js
-const ipcBusModule = require("electron-common-ipc");
-const ipcBus = ipcBusModule.IpcBusClient.Create();
+const electronCommonIpc = require('electron-common-ipc');
+if (electronCommonIpc.PreloadElectronCommonIpc()) {
+  electronCommonIpc.ActivateIpcBusTrace(true);
+  window.ipcBus = window.ElectronCommonIpc.CreateIpcBusClient();
+  window.ipcBus.IPCBUS_CHANNEL_QUERY_STATE = electronCommonIpc.IPCBUS_CHANNEL_QUERY_STATE;
+}
+```
+if not, just type this code in your renderer process:
+```js
+if (electronCommonIpc.PreloadElectronCommonIpc()) {
+    electronCommonIpc.ActivateIpcBusTrace(true);
+    const ipcBus = window.ElectronCommonIpc.CreateIpcBusClient();
+}
 ```
 
 NOTE: There is no notion of port, buspath in a renderer. IpcBusRenderer connects automatically to the instance of the bridge.

--- a/examples/test-app/BrowserWindowPreload.js
+++ b/examples/test-app/BrowserWindowPreload.js
@@ -4,10 +4,11 @@
 'use strict';
 
 const electronCommonIpc = require('electron-common-ipc');
-electronCommonIpc.PreloadElectronCommonIpc();
-electronCommonIpc.ActivateIpcBusTrace(true);
-window.ipcBus = electronCommonIpc.IpcBusClient.Create();
-window.ipcBus.IPCBUS_CHANNEL_QUERY_STATE = electronCommonIpc.IPCBUS_CHANNEL_QUERY_STATE;
+if (electronCommonIpc.PreloadElectronCommonIpc()) {
+  electronCommonIpc.ActivateIpcBusTrace(true);
+  window.ipcBus = window.ElectronCommonIpc.CreateIpcBusClient();
+  window.ipcBus.IPCBUS_CHANNEL_QUERY_STATE = electronCommonIpc.IPCBUS_CHANNEL_QUERY_STATE;
+}
 
 window.ipcRenderer = require('electron').ipcRenderer;
 

--- a/examples/test-app/Main.js
+++ b/examples/test-app/Main.js
@@ -26,7 +26,8 @@ console.log('IPC Bus Path : ' + busPath);
 
 // IPC Bus
 const ipcBusModule = require('electron-common-ipc');
-const ipcBusClient = ipcBusModule.IpcBusClient.Create(busPath);
+// const ipcBusClient = ipcBusModule.IpcBusClient.Create(busPath);
+const ipcBusClient = ipcBusModule.CreateIpcBusClient(busPath);
 // ipcBusModule.ActivateIpcBusTrace(true);
 // ipcBusModule.ActivateServiceTrace(true);
 
@@ -59,7 +60,7 @@ function spawnNodeInstance(scriptPath) {
 }
 
 // Window const
-const preloadFile = path.join(__dirname, 'BundledBrowserWindowPreload.js');
+const preloadFile = path.join(__dirname, 'BrowserWindowPreload.js');
 const commonViewUrl = 'file://' + path.join(__dirname, 'CommonView.html');
 const perfViewUrl = 'file://' + path.join(__dirname, 'PerfView.html');
 const width = 1000;

--- a/examples/test-app/package.json
+++ b/examples/test-app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "electron": "^6.0.0",
-    "electron-common-ipc": "^4.0.0",
+    "electron-common-ipc": "^6.6.0",
     "typescript": "^2.5.2",
     "uuid": "2.0.3"
   }


### PR DESCRIPTION
fix: fixed error of test-app code

- ipcClient's Create function not exist in strict mode, so use CreateIpcBusClient function to create client. (475c2e2)
- fixed wrong function call to create ipcBusClient in BrowserWindowPreload (475c2e2)
- electron-common-ipc version up to ^6.6.0 in test-app(a4992fc)
- docs: update docs about create ipcBusClient in renderer process(07057cd)