### PR TITLE
Add ability to dispose remote proxy service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-common-ipc",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "A safe IPC bus for applications built on Node or Electron.",
   "repository": {
     "type": "git",
@@ -54,6 +54,7 @@
     "@types/node": "12.7.12",
     "@types/semver": "^7.2.0",
     "@types/shortid": "0.0.29",
+    "@types/sinon": "^9.0.8",
     "@types/uuid": "8.0.0",
     "browserify": "^16.5.1",
     "chai": "^4.2.0",
@@ -89,7 +90,7 @@
     "browserify-test:js2": "browserify -o ./test/electron-tests/page-frame.bundle.js -x electron ./test/electron-tests/page.js",
     "browserify-test:performance-preload": "browserify -o ./test/performance/renderer-preload.bundle.js -x electron ./test/performance/renderer-preload.js",
     "browserify-test:performance-renderer": "browserify -o ./test/performance/renderer.bundle.js -x electron ./test/performance/renderer.js",
-    "test": "electron-mocha --no-timeouts --reporter spec test/*.test.js",
+    "test": "electron-mocha --no-timeouts --reporter spec test/**/*.test.js",
     "test:performance": "electron-mocha --no-timeouts --reporter spec test/performance.test.js",
     "tsc": "tsc",
     "tslint": "tslint",

--- a/src/IpcBus/service/IpcBusService.ts
+++ b/src/IpcBus/service/IpcBusService.ts
@@ -52,6 +52,7 @@ export interface IpcBusServiceProxy extends EventEmitter {
     connect<T>(options?: IpcBusServiceProxy.ConnectOptions): Promise<T>;
     getStatus(): Promise<ServiceStatus>;
     getWrapper<T>(): T;
+    close(): void;
 
     // Kept for backward
     call<T>(name: string, ...args: any[]): Promise<T>;

--- a/test/unit/service/IpcBusServiceProxy.test.js
+++ b/test/unit/service/IpcBusServiceProxy.test.js
@@ -1,0 +1,98 @@
+const sinon = require('sinon');
+const expect = require('expect');
+const { IpcBusClientImpl } = require('../../../lib/IpcBus/IpcBusClientImpl');
+const { IpcBusServiceProxyImpl } = require('../../../lib/IpcBus/service/IpcBusServiceProxyImpl');
+const { IPCBUS_SERVICE_EVENT_START, IPCBUS_SERVICE_EVENT_STOP } = require('../../../lib/IpcBus/service/IpcBusService');
+const { IPCBUS_SERVICE_CALL_GETSTATUS } = require('../../../lib/IpcBus/service/IpcBusServiceUtils');
+const { IpcBusTransportMultiImpl } = require('../../../lib/IpcBus/IpcBusTransportMultiImpl');
+const serviceUtils = require('../../../lib/IpcBus/service/IpcBusServiceUtils');
+
+describe('IpcBusServiceProxy', () => {
+    let ipcBusClientMock;
+
+    beforeEach(() => {
+        const transportStub = sinon.createStubInstance(IpcBusTransportMultiImpl);
+        this.ipcBusClientMock = sinon.mock(new IpcBusClientImpl(transportStub));
+    });
+
+    it('Should release the subscription if remove service is not started', () => {
+        const serviceName = 'service-1';
+        const serviceEventChannel = serviceUtils.getServiceEventChannel(serviceName);
+        this.ipcBusClientMock.expects('request').resolves({});
+        this.ipcBusClientMock.expects('addListener').callThrough().calledOnceWith(serviceEventChannel, sinon.match.any);
+        this.ipcBusClientMock.expects('removeListener').callThrough().calledOnceWith(serviceEventChannel, sinon.match.any);
+        const testServiceProxy = new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, serviceName);
+        testServiceProxy.connect();
+        testServiceProxy.close();
+        this.ipcBusClientMock.verify();
+    });
+
+    it('Should remove all listeners the closed', () => {
+        this.ipcBusClientMock.expects('request').resolves({});
+        const testServiceProxy = new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, 'service-1');
+        testServiceProxy.connect();
+        expect(testServiceProxy._eventsCount).toEqual(1);
+        testServiceProxy.close();
+        expect(testServiceProxy._eventsCount).toEqual(0);
+    });
+
+    it('Should subscribe to start event if service is not available', () => {
+        this.ipcBusClientMock.expects('request').resolves({});
+        const testServiceProxy = new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, 'service-1');
+        testServiceProxy.connect();
+        expect(testServiceProxy.listenerCount(IPCBUS_SERVICE_EVENT_START)).toEqual(1);
+    });
+
+    it('Should successfully open connection after if was closed', async () => {
+        this.ipcBusClientMock.expects('request').exactly(2).resolves({ payload: { started: true, callHandlers: [] } });
+        const testServiceProxy = new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, 'service-1');
+        await testServiceProxy.connect();
+        testServiceProxy.close();
+        await testServiceProxy.connect();
+        expect(testServiceProxy.isStarted).toEqual(true);
+        this.ipcBusClientMock.verify();
+    });
+
+    it('Should not have any effect if close was called before connect', async () => {
+        this.ipcBusClientMock.expects('request').exactly(2).resolves({ payload: { started: true, callHandlers: [] } });
+        const testServiceProxy = new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, 'service-1');
+        testServiceProxy.close();
+        await testServiceProxy.connect();
+        expect(testServiceProxy.isStarted).toEqual(true);
+        this.ipcBusClientMock.verify();
+    });
+
+    it('Should call request method to ask remote service state while constructing', () => {
+        const serviceName = 'service-1';
+        const serviceEventChannel = serviceUtils.getServiceCallChannel(serviceName);
+        const callMsg = { handlerName: IPCBUS_SERVICE_CALL_GETSTATUS, args: [] };
+        this.ipcBusClientMock.expects('request').exactly(1).withExactArgs(serviceEventChannel, -1, callMsg).resolves({});
+        new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, serviceName);
+        this.ipcBusClientMock.verify();
+    });
+
+    it('Should return "false" when calling isStarted after close', async () => {
+        this.ipcBusClientMock.expects('request').resolves({ payload: { started: true, callHandlers: [] } });
+        const testServiceProxy = new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, 'service-1');
+        await testServiceProxy.connect();
+        testServiceProxy.close();
+        expect(testServiceProxy.isStarted).toEqual(false);
+    });
+
+    it('Should emit start event when services is connected', async () => {
+        this.ipcBusClientMock.expects('request').resolves({ payload: { started: true, callHandlers: [] } });
+        const testServiceProxy = new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, 'service-1');
+        testServiceProxy.emit = sinon.spy(testServiceProxy.emit);
+        await testServiceProxy.connect();
+        expect(testServiceProxy.emit.calledOnceWith(IPCBUS_SERVICE_EVENT_START, sinon.match.any)).toEqual(true);
+    });
+
+    it('Should emit stop event if stopped explicitly', async () => {
+        this.ipcBusClientMock.expects('request').resolves({ payload: { started: true, callHandlers: [] } });
+        const testServiceProxy = new IpcBusServiceProxyImpl(this.ipcBusClientMock.object, 'service-1');
+        testServiceProxy.emit = sinon.spy(testServiceProxy.emit);
+        await testServiceProxy.connect();
+        testServiceProxy.close();
+        expect(testServiceProxy.emit.lastCall.firstArg).toEqual(IPCBUS_SERVICE_EVENT_STOP);
+    });
+});


### PR DESCRIPTION
Fixed memory leak where the IpcBusProxyService cannot be disposed properly because of the reference to IpcBusClient + handler link in IpcBusClient