### PR TITLE
- add 'process' explicit polyfill to allow disabling global detection from the client side

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "fs-extra": "^10.0.0",
     "json-helpers": "~5.1.4",
     "nanoid": "^3.1.30",
+    "process": "^0.11.10",
     "socket-serializer": "^11.1.1",
     "uuid": "~8.3.2",
     "winston": "~3.3.3"
@@ -66,6 +67,7 @@
     "npm-dts": "^1.3.10",
     "npm-run-all": "~4.1.5",
     "sinon": "^12.0.1",
+    "socket-port-helpers": "^2.1.0",
     "typescript": "^4.5.4"
   },
   "scripts": {

--- a/src/IpcBus/renderer/IpcBusConnectorRenderer.ts
+++ b/src/IpcBus/renderer/IpcBusConnectorRenderer.ts
@@ -1,5 +1,7 @@
 /// <reference types='electron' />
 
+const processPolyfill = require('process/browser');
+
 import * as assert from 'assert';
 import type { EventEmitter } from 'events';
 
@@ -74,7 +76,7 @@ export class IpcBusConnectorRenderer extends IpcBusConnectorImpl {
     protected onIPCMessageReceived(event: Electron.IpcRendererEvent, ipcMessage: IpcBusMessage, data: any) {
         // It may happen Electron is breaking the JS context when messages are emitted very fast
         // especially when processing of each takes time. So delay the code excecuted for an event.
-        process.nextTick(() => {
+        processPolyfill.nextTick(() => {
             if (ipcMessage.isRawData) {
                 // Electron IPC "corrupts" Buffer to a Uint8Array
                 IpcBusRendererContent.FixRawContent(data);
@@ -87,7 +89,7 @@ export class IpcBusConnectorRenderer extends IpcBusConnectorImpl {
     }
 
     protected onPortMessageReceived(event: MessageEvent) {
-        process.nextTick(() => {
+        processPolyfill.nextTick(() => {
             const [ipcMessage, data] = event.data;
             if (ipcMessage.isRawData) {
                 // Electron IPC "corrupts" Buffer to a Uint8Array


### PR DESCRIPTION
add 'process' explicit polyfill to allow disabling global detection from the client-side