### PR TITLE
Update socket-serializer package to ^12.0.1

### DIFF
--- a/.github/workflows/npm-publish-manual.yml
+++ b/.github/workflows/npm-publish-manual.yml
@@ -58,8 +58,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
         shell: bash
         run: |
-          git config user.name "ci.bot"
-          git config user.email "ci.bot@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           
           bump_message="\"chore(release): manual package versions update\""
           force_publish="" && [[ -n "${{ inputs.force_publish }}" ]] && force_publish="--force-publish=${{ inputs.force_publish }}"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,5 @@
 name: publish
-run-name: Pull request publish. Actor is "${{ github.actor }}". Target branch is "${{ github.base_ref }}
+run-name: Pull request publish. Actor is "${{ github.actor }}". Target branch is "${{ github.base_ref }}"
 
 on:
   pull_request_target:
@@ -32,8 +32,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
         shell: bash
         run: |
-          git config user.name "ci.bot"
-          git config user.email "ci.bot@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           
           target_branch="${{ github.base_ref }}"
           bump_message="\"chore(release): update package versions\""

--- a/packages/internal/e2e-tests/package.json
+++ b/packages/internal/e2e-tests/package.json
@@ -11,7 +11,10 @@
     "test:perf:node": "mocha ./build/config.js ./build/perf/*-node/**/*.test.js --no-timeout",
     "test:perf:browser": "electron-mocha ./build/config.js ./build/perf/*-browser/**/*.test.js --no-timeout",
     "test:browser": "electron-mocha ./build/config.js ./build/browser/**/*test.js --no-timeout",
-    "pack:bundles": "webpack"
+    "pack:bundles": "webpack --mode development -d inline-source-map",
+    "pack:stats": "run-s pack:bundles:profile pack:bundles:analyze",
+    "pack:bundles:profile": "webpack --profile --json --mode production > ./build/stats.json",
+    "pack:bundles:analyze": "webpack-bundle-analyzer ./build/stats.json"
   },
   "devDependencies": {
     "@electron-common-ipc/eslint-config": "*",
@@ -35,6 +38,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",
     "webpack": "^5.75.0",
+    "webpack-bundle-analyzer": "^4.7.0",
     "webpack-cli": "^4.10.0"
   },
   "prettier": "@electron-common-ipc/prettier-config"

--- a/packages/internal/e2e-tests/webpack.config.js
+++ b/packages/internal/e2e-tests/webpack.config.js
@@ -3,9 +3,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 
 const webConfig = {
-    mode: 'development',
     entry: './test/browser/echo-client/browser-client.ts',
-    devtool: 'inline-source-map',
     target: 'web',
     module: {
         rules: [
@@ -17,12 +15,6 @@ const webConfig = {
         ],
     },
     resolve: {
-        fallback: {
-            'buffer': require.resolve('buffer'),
-            'events': require.resolve('events'),
-            'path': false,
-            'fs': false
-        },
         extensions: ['.ts', '.js'],
     },
     output: {
@@ -33,9 +25,6 @@ const webConfig = {
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
         }),
-        new webpack.ProvidePlugin({
-            process: 'process/browser',
-        }),
         new CopyPlugin({
             patterns: [{
                 from: './test/browser/echo-client/browser-index.html',
@@ -45,9 +34,7 @@ const webConfig = {
 };
 
 const preloadConfig = {
-    mode: 'development',
     entry: './test/browser/echo-client/browser-preload.ts',
-    devtool: 'inline-source-map',
     target: 'electron-renderer',
     module: {
         rules: [

--- a/packages/ipc-bus/package.json
+++ b/packages/ipc-bus/package.json
@@ -47,7 +47,7 @@
         "nanoid": "^3.1.30",
         "queue-microtask": "^1.2.3",
         "semver": "^7.3.5",
-        "socket-serializer": "^11.1.1",
+        "socket-serializer": "^12.0.1",
         "uuid": "^8.3.2",
         "winston": "~3.3.3"
     },

--- a/packages/universal/package.json
+++ b/packages/universal/package.json
@@ -59,7 +59,7 @@
         "prettier": "^2.7.1",
         "rimraf": "^3.0.2",
         "sinon": "^13.0.1",
-        "socket-serializer": "^11.1.1",
+        "socket-serializer": "^12.0.1",
         "ts-node": "^10.9.1",
         "ts-sinon": "^2.0.2",
         "typescript": "^4.8.4"

--- a/packages/web-socket-browser/package.json
+++ b/packages/web-socket-browser/package.json
@@ -49,7 +49,7 @@
         "@electron-common-ipc/universal": "^1.0.1-dev.2",
         "json-helpers": "^5.2.0",
         "nanoid": "^3.1.30",
-        "socket-serializer": "^11.1.1",
+        "socket-serializer": "^12.0.1",
         "ws": "^8.9.0"
     },
     "devDependencies": {

--- a/packages/web-socket/package.json
+++ b/packages/web-socket/package.json
@@ -48,7 +48,7 @@
         "@electron-common-ipc/universal": "^1.0.1-dev.2",
         "json-helpers": "^5.2.0",
         "nanoid": "^3.1.30",
-        "socket-serializer": "^11.1.1",
+        "socket-serializer": "^12.0.1",
         "ws": "^8.9.0"
     },
     "devDependencies": {


### PR DESCRIPTION
- socket-serializer was updated to reduce bundle size (from 330kb to 264kb) and improve performance
- added ability in the @electron-common-ipc/e2e-tests to review the webpack bundle be running "npm run pack:stats"
- minor fixes on the GitHub workflows