### PR TITLE
Remove peer knowledge from connector.

### DIFF
--- a/packages/internal/e2e-tests/test/internal/clients/echo-client.ts
+++ b/packages/internal/e2e-tests/test/internal/clients/echo-client.ts
@@ -87,8 +87,6 @@ export async function bootstrapEchoClient(ctx: BootstrapContext): Promise<IpcBus
                 ipcClient.addListener(message.channel, requestResolveTo.bind(globalThis, message.data));
                 break;
             case 'start-echo-service': {
-                // eslint-disable-next-line no-debugger
-                debugger;
                 echoServiceInstance = new EchoServiceClass();
                 echoService = ctx.createIpcBusService(ipcClient, message.channel, echoServiceInstance);
                 echoService.start();
@@ -139,6 +137,8 @@ export async function bootstrapEchoClient(ctx: BootstrapContext): Promise<IpcBus
         ctx.sendBack('done');
     });
 
+    // eslint-disable-next-line no-debugger
+    // debugger;
     await ipcClient.connect(ctx.clientPort, { timeoutDelay: -1 });
     ctx.sendBack('ready');
     return ipcClient;

--- a/packages/internal/e2e-tests/test/internal/suites/eipc-suite.ts
+++ b/packages/internal/e2e-tests/test/internal/suites/eipc-suite.ts
@@ -1,4 +1,4 @@
-import { GlobalContainer, IpcBusProcessType } from '@electron-common-ipc/universal';
+import { GlobalContainer } from '@electron-common-ipc/universal';
 import { expect } from 'chai';
 import { findFirstFreePort } from 'socket-port-helpers';
 
@@ -316,8 +316,8 @@ export function shouldRunEipcRemoteBrokerTests(suiteId: string, ctx: EipcContext
                 );
                 const rendererConnector = mainEntry.find((x) => x.type === 'connector-renderer') as QueryStateConnector;
 
-                expect(rendererConnector.peer).to.exist;
-                expect(rendererConnector.peer.type).to.be.eq(IpcBusProcessType.Renderer);
+                expect(rendererConnector.id).to.exist;
+                expect(rendererConnector.contextId).to.exist;
             });
 
             // check message stamp?

--- a/packages/ipc-bus/src/main/IpcBusClientMain-factory.ts
+++ b/packages/ipc-bus/src/main/IpcBusClientMain-factory.ts
@@ -2,9 +2,10 @@ import { IpcBusClientImpl } from '@electron-common-ipc/universal';
 import { EventEmitter } from 'events';
 
 import { newIpcBusBridge } from './IpcBusBridge-factory';
+import { uuidProvider } from '../utils/uuid';
 
 import type { IpcBusBridgeImpl } from './IpcBusBridgeImpl';
-import type { IpcBusClient, IpcBusTransport , IpcBusPeer } from '@electron-common-ipc/universal';
+import type { IpcBusClient, IpcBusTransport, IpcBusPeer } from '@electron-common-ipc/universal';
 
 function createTransport(): IpcBusTransport {
     const bridge = newIpcBusBridge() as IpcBusBridgeImpl;
@@ -15,7 +16,7 @@ function createTransport(): IpcBusTransport {
 // Implementation for Electron Main process
 export function createIpcBusClient(): IpcBusClient {
     const transport = createTransport();
-    const ipcClient = new IpcBusClientImpl(new EventEmitter(), transport);
+    const ipcClient = new IpcBusClientImpl(uuidProvider, new EventEmitter(), transport);
     return ipcClient;
 }
 

--- a/packages/ipc-bus/src/main/IpcBusMainBridge.ts
+++ b/packages/ipc-bus/src/main/IpcBusMainBridge.ts
@@ -14,6 +14,7 @@ import type {
     IpcBusMessage,
     IpcBusProcessType,
     UuidProvider,
+    IpcBusPeer,
 } from '@electron-common-ipc/universal';
 
 export class IpcBusBridgeConnectorMain extends IpcBusConnectorImpl {
@@ -28,14 +29,18 @@ export class IpcBusBridgeConnectorMain extends IpcBusConnectorImpl {
         return GetTargetMain(ipcMessage) !== undefined;
     }
 
-    handshake(_client: IpcBusConnectorClient, _options: ClientConnectOptions): Promise<ConnectorHandshake> {
+    protected override handshakeInternal(
+        _client: IpcBusConnectorClient,
+        peer: IpcBusPeer,
+        _options: ClientConnectOptions
+    ): Promise<ConnectorHandshake> {
         const handshake: ConnectorHandshake = {
-            peer: this._peer,
+            peer,
         };
         return Promise.resolve(handshake);
     }
 
-    shutdown(_options: ClientCloseOptions): Promise<void> {
+    protected override shutdownInternal(_options: ClientCloseOptions): Promise<void> {
         return Promise.resolve();
     }
 
@@ -54,7 +59,6 @@ export class IpcBusBridgeConnectorMain extends IpcBusConnectorImpl {
 
             case IpcBusCommandKind.AddChannelListener:
             case IpcBusCommandKind.RemoveChannelListener:
-                ipcCommand.peer = ipcCommand.peer || this.peer;
                 this._bridge._onBridgeChannelChanged(ipcCommand);
                 break;
 

--- a/packages/ipc-bus/src/main/IpcBusQueryState-collector.ts
+++ b/packages/ipc-bus/src/main/IpcBusQueryState-collector.ts
@@ -1,4 +1,4 @@
-import { IpcBusCommandKind } from '@electron-common-ipc/universal';
+import { IpcBusCommandKind, IpcBusProcessType } from '@electron-common-ipc/universal';
 
 import { uuidProvider } from '../utils/uuid';
 
@@ -27,6 +27,7 @@ export class IpcBusQueryStateManager {
         this._session = uuidProvider();
         const ipcQueryState: IpcBusCommand = {
             kind: IpcBusCommandKind.QueryState,
+            peer: { id: 'query-state-collector', type: IpcBusProcessType.Main },
             channel: this._session,
         };
         const rendererQueryState = this._bridge.rendererTransport.queryState();

--- a/packages/ipc-bus/src/node/IpcBusBrokerNode.ts
+++ b/packages/ipc-bus/src/node/IpcBusBrokerNode.ts
@@ -44,10 +44,12 @@ export class IpcBusBrokerNode extends BrokerImpl {
                 this._subscribedChannels.addRefs(ipcCommand.channels);
             }
 
+            const bridgeMockPeer = { id: 'broker-node', type: this._contextType };
             const channels = this._subscriptions.getChannels();
             for (let i = 0, l = channels.length; i < l; ++i) {
                 this.broadcastCommandToBridge({
                     kind: IpcBusCommandKind.AddChannelListener,
+                    peer: bridgeMockPeer,
                     channel: channels[i],
                 });
             }
@@ -55,12 +57,14 @@ export class IpcBusBrokerNode extends BrokerImpl {
                 channelAdded: (channel) => {
                     this.broadcastCommandToBridge({
                         kind: IpcBusCommandKind.AddChannelListener,
+                        peer: bridgeMockPeer,
                         channel,
                     });
                 },
                 channelRemoved: (channel) => {
                     this.broadcastCommandToBridge({
                         kind: IpcBusCommandKind.RemoveChannelListener,
+                        peer: bridgeMockPeer,
                         channel,
                     });
                 },

--- a/packages/ipc-bus/src/node/IpcBusClientSocket-factory.ts
+++ b/packages/ipc-bus/src/node/IpcBusClientSocket-factory.ts
@@ -35,6 +35,6 @@ function createTransport(contextType: IpcBusProcessType): IpcBusTransport {
 // Implementation for Node process
 export function createIpcBusClient(): IpcBusClient {
     const transport = createTransport(IpcBusProcessType.Node);
-    const ipcClient = new IpcBusClientImpl(new EventEmitter(), transport);
+    const ipcClient = new IpcBusClientImpl(uuidProvider, new EventEmitter(), transport);
     return ipcClient;
 }

--- a/packages/ipc-bus/src/node/IpcBusConnectorSocket.ts
+++ b/packages/ipc-bus/src/node/IpcBusConnectorSocket.ts
@@ -23,6 +23,7 @@ import type {
     IpcBusMessage,
     Logger,
     UuidProvider,
+    IpcBusPeer,
 } from '@electron-common-ipc/universal';
 import type { Writer } from 'socket-serializer';
 
@@ -31,6 +32,7 @@ import type { Writer } from 'socket-serializer';
 export class IpcBusConnectorSocket extends IpcBusConnectorImpl {
     private _socket: net.Socket;
     private readonly _netBinds: { [key: string]: (...args: any[]) => void };
+    private _localBinds: typeof this._netBinds = {};
 
     private _socketBuffer: number;
     private _socketWriter: Writer;
@@ -40,10 +42,10 @@ export class IpcBusConnectorSocket extends IpcBusConnectorImpl {
     private readonly _serializeMessage: SerializeMessage;
     private readonly _bufferListReader: BufferListReader;
 
-    constructor(uuid: UuidProvider, contextType: IpcBusProcessType, private readonly _logger?: Logger) {
+    constructor(uuid: UuidProvider, contextType: IpcBusProcessType, logger?: Logger) {
         // assert((contextType === 'main') || (contextType === 'node'),
         // `IpcBusTransportNet: contextType must not be a ${contextType}`);
-        super(uuid, contextType, 'connector-socket');
+        super(uuid, contextType, 'connector-socket', logger);
 
         this._bufferListReader = new BufferListReader();
         this._packetIn = new IpcPacketBufferList();
@@ -63,7 +65,7 @@ export class IpcBusConnectorSocket extends IpcBusConnectorImpl {
 
     // https://nodejs.org/api/net.html#net_event_error_1
     protected _onSocketError(err: Error) {
-        const msg = `[IPCBusTransport:Net ${this._peer.id}] socket error ${err}`;
+        const msg = `[IPCBusTransport:Net ${this.id}] socket error ${err}`;
         this._logger?.error(msg);
         // this._socket.destroy();
         this.onConnectorShutdown();
@@ -72,7 +74,7 @@ export class IpcBusConnectorSocket extends IpcBusConnectorImpl {
 
     // https://nodejs.org/api/net.html#net_event_close_1
     protected _onSocketClose() {
-        const msg = `[IPCBusTransport:Net ${this._peer.id}] socket close`;
+        const msg = `[IPCBusTransport:Net ${this.id}] socket close`;
         this._logger?.info(msg);
         this.onConnectorShutdown();
         this._reset(false);
@@ -80,7 +82,7 @@ export class IpcBusConnectorSocket extends IpcBusConnectorImpl {
 
     // https://nodejs.org/api/net.html#net_event_end
     protected _onSocketEnd() {
-        const msg = `[IPCBusTransport:Net ${this._peer.id}] socket end`;
+        const msg = `[IPCBusTransport:Net ${this.id}] socket end`;
         this._logger?.info(msg);
         this.onConnectorShutdown();
         this._reset(false);
@@ -136,151 +138,123 @@ export class IpcBusConnectorSocket extends IpcBusConnectorImpl {
         }
     }
 
-    isTarget(ipcMessage: IpcBusMessage): boolean {
-        return ipcMessage.peer.id === this.peer.id;
-    }
-
     /// IpcBusTransportImpl API
-    handshake(client: IpcBusConnectorClient, options: ClientConnectOptions): Promise<ConnectorHandshake> {
-        return this._connectCloseState.connect(() => {
-            return new Promise((resolve, reject) => {
-                options = CheckConnectOptions(options);
-                if (!options.port && !options.path) {
-                    reject('Connection options not provided');
-                    return;
-                }
+    protected override handshakeInternal(
+        client: IpcBusConnectorClient,
+        peer: IpcBusPeer,
+        options: ClientConnectOptions
+    ): Promise<ConnectorHandshake> {
+        return new Promise((resolve, reject) => {
+            options = CheckConnectOptions(options);
+            if (!options.port && !options.path) {
+                reject('Connection options not provided');
+                return;
+            }
 
-                this._socketBuffer = options.socketBuffer;
+            this._socketBuffer = options.socketBuffer;
 
-                let timer: NodeJS.Timer = undefined;
-                let fctReject: (msg: string) => void = () => {};
-                // Below zero = infinite
-                if (options.timeoutDelay >= 0) {
-                    timer = setTimeout(() => {
-                        timer = undefined;
-                        const msg = `[IPCBusTransport:Net ${this._peer.id}] error = timeout (${
-                            options.timeoutDelay
-                        } ms) on ${JSON.stringify(options)}`;
-                        fctReject(msg);
-                    }, options.timeoutDelay);
-                }
-
-                const catchError = (err: unknown) => {
-                    const msg = `[IPCBusTransport:Net ${this._peer.id}] socket error = ${err} on ${JSON.stringify(
-                        options
-                    )}`;
+            let timer: NodeJS.Timer = undefined;
+            let fctReject: (msg: string) => void = () => {};
+            // Below zero = infinite
+            if (options.timeoutDelay >= 0) {
+                timer = setTimeout(() => {
+                    timer = undefined;
+                    const msg = `[IPCBusTransport:Net ${this.id}] error = timeout (${
+                        options.timeoutDelay
+                    } ms) on ${JSON.stringify(options)}`;
                     fctReject(msg);
-                };
+                }, options.timeoutDelay);
+            }
 
-                const catchClose = () => {
-                    const msg = `[IPCBusTransport:Net ${this._peer.id}] socket close`;
-                    fctReject(msg);
-                };
+            const catchError = (err: unknown) => {
+                const msg = `[IPCBusTransport:Net ${this.id}] socket error = ${err} on ${JSON.stringify(options)}`;
+                fctReject(msg);
+            };
 
-                const socket = new net.Socket();
-                socket.unref();
-                const socketLocalBinds: { [key: string]: (...args: any[]) => void } = {};
-                const catchConnect = () => {
-                    clearTimeout(timer);
+            const catchClose = () => {
+                const msg = `[IPCBusTransport:Net ${this.id}] socket close`;
+                fctReject(msg);
+            };
 
-                    this.addClient(client);
-                    for (const key in socketLocalBinds) {
-                        socket.removeListener(key, socketLocalBinds[key]);
-                    }
-                    this._socket = socket;
-                    for (const key in this._netBinds) {
-                        this._socket.addListener(key, this._netBinds[key]);
-                    }
+            const socket = new net.Socket();
+            socket.unref();
+            const catchConnect = () => {
+                clearTimeout(timer);
 
-                    this._logger?.info(
-                        `[IPCBusTransport:Net ${this._peer.id}] connected on ${JSON.stringify(options)}`
-                    );
-                    if (!this._socketBuffer) {
-                        this._socketWriter = new SocketWriter(this._socket);
-                    } else if (this._socketBuffer < 0) {
-                        this._socketWriter = new DelayedSocketWriter(this._socket);
-                    } else if (this._socketBuffer > 0) {
-                        this._socketWriter = new BufferedSocketWriter(this._socket, this._socketBuffer);
-                    }
-
-                    this.onConnectorHandshake();
-
-                    const handshake: ConnectorHandshake = {
-                        peer: this._peer,
-                    };
-                    resolve(handshake);
-                };
-
-                fctReject = (msg: string) => {
-                    clearTimeout(timer);
-                    for (const key in socketLocalBinds) {
-                        socket.removeListener(key, socketLocalBinds[key]);
-                    }
-                    this._reset(false);
-                    this._logger?.error(msg);
-                    reject(msg);
-                };
-                socketLocalBinds['error'] = catchError.bind(this);
-                socketLocalBinds['close'] = catchClose.bind(this);
-                socketLocalBinds['connect'] = catchConnect.bind(this);
-                for (const key in socketLocalBinds) {
-                    socket.addListener(key, socketLocalBinds[key]);
+                this.addClient(client);
+                this._removeLocalBinds();
+                this._socket = socket;
+                for (const key in this._netBinds) {
+                    this._socket.addListener(key, this._netBinds[key]);
                 }
-                if (options.path) {
-                    socket.connect(options.path);
-                } else if (options.port && options.host) {
-                    socket.connect(options.port, options.host);
-                } else {
-                    socket.connect(options.port);
+
+                this._logger?.info(`[IPCBusTransport:Net ${this.id}] connected on ${JSON.stringify(options)}`);
+                if (!this._socketBuffer) {
+                    this._socketWriter = new SocketWriter(this._socket);
+                } else if (this._socketBuffer < 0) {
+                    this._socketWriter = new DelayedSocketWriter(this._socket);
+                } else if (this._socketBuffer > 0) {
+                    this._socketWriter = new BufferedSocketWriter(this._socket, this._socketBuffer);
                 }
-            });
+
+                const handshake: ConnectorHandshake = {
+                    peer,
+                };
+                resolve(handshake);
+            };
+
+            fctReject = (msg: string) => {
+                clearTimeout(timer);
+                this._removeLocalBinds();
+                this._reset(false);
+                this._logger?.error(msg);
+                reject(msg);
+            };
+            this._localBinds['error'] = catchError.bind(this);
+            this._localBinds['close'] = catchClose.bind(this);
+            this._localBinds['connect'] = catchConnect.bind(this);
+            for (const key in this._localBinds) {
+                socket.addListener(key, this._localBinds[key]);
+            }
+            if (options.path) {
+                socket.connect(options.path);
+            } else if (options.port && options.host) {
+                socket.connect(options.port, options.host);
+            } else {
+                socket.connect(options.port);
+            }
         });
     }
 
-    shutdown(options?: ClientCloseOptions): Promise<void> {
-        return this._connectCloseState.close(() => {
-            options = options || {};
-            if (options.timeoutDelay === undefined) {
-                options.timeoutDelay = IPC_BUS_TIMEOUT;
-            }
-            return new Promise<void>((resolve, reject) => {
-                if (this._socket) {
-                    let timer: NodeJS.Timer;
-                    const socket = this._socket;
-                    const socketLocalBinds: { [key: string]: (...args: any[]) => void } = {};
-                    const catchClose = () => {
-                        clearTimeout(timer);
-                        for (const key in socketLocalBinds) {
-                            socket.removeListener(key, socketLocalBinds[key]);
-                        }
-                        this.onConnectorShutdown();
-                        socket.destroy();
-                        resolve();
-                    };
-                    // Below zero = infinite
-                    if (options.timeoutDelay >= 0) {
-                        timer = setTimeout(() => {
-                            for (const key in socketLocalBinds) {
-                                socket.removeListener(key, socketLocalBinds[key]);
-                            }
-                            const msg = `[IPCBusTransport:Net ${this._peer.id}] stop, error = timeout (${
-                                options.timeoutDelay
-                            } ms) on ${JSON.stringify(options)}`;
-                            this._logger?.error(msg);
-                            this.onConnectorShutdown();
-                            reject(msg);
-                        }, options.timeoutDelay);
+    protected override shutdownInternal(options?: ClientCloseOptions): Promise<void> {
+        options = options || {};
+        if (options.timeoutDelay === undefined) {
+            options.timeoutDelay = IPC_BUS_TIMEOUT;
+        }
+
+        this._removeLocalBinds();
+        return new Promise<void>((resolve) => {
+            if (this._socket) {
+                let timer: NodeJS.Timer;
+                const socket = this._socket;
+                const catchClose = () => {
+                    clearTimeout(timer);
+                    for (const key in this._localBinds) {
+                        socket.removeListener(key, this._localBinds[key]);
                     }
-                    socketLocalBinds['close'] = catchClose.bind(this);
-                    for (const key in socketLocalBinds) {
-                        socket.addListener(key, socketLocalBinds[key]);
-                    }
-                    this.onConnectorBeforeShutdown();
-                    this._reset(true);
-                } else {
+                    this.onConnectorShutdown();
+                    socket.destroy();
                     resolve();
+                };
+
+                this._localBinds['close'] = catchClose.bind(this);
+                for (const key in this._localBinds) {
+                    socket.addListener(key, this._localBinds[key]);
                 }
-            });
+                this._reset(true);
+            } else {
+                resolve();
+            }
         });
     }
 
@@ -293,8 +267,14 @@ export class IpcBusConnectorSocket extends IpcBusConnectorImpl {
 
     postCommand(ipcCommand: IpcBusCommand): void {
         if (this._socketWriter) {
-            ipcCommand.peer = ipcCommand.peer || this._peer;
             this._serializeMessage.writeCommand(this._socketWriter, ipcCommand);
         }
+    }
+
+    private _removeLocalBinds(): void {
+        for (const key in this._localBinds) {
+            this._socket?.removeListener(key, this._localBinds[key]);
+        }
+        this._localBinds = {};
     }
 }

--- a/packages/ipc-bus/src/renderer/IpcBusClientRenderer-factory.ts
+++ b/packages/ipc-bus/src/renderer/IpcBusClientRenderer-factory.ts
@@ -42,6 +42,6 @@ export function newIpcBusClient(
     ipcWindow: IpcWindow
 ): IpcBusClient {
     const transport = createTransport(contextType, isMainFrame, ipcWindow);
-    const ipcClient = new IpcBusClientImpl(new EventEmitter(), transport);
+    const ipcClient = new IpcBusClientImpl(uuidProvider, new EventEmitter(), transport);
     return ipcClient;
 }

--- a/packages/universal/src/broker/broker.ts
+++ b/packages/universal/src/broker/broker.ts
@@ -13,7 +13,7 @@ export type BrokerCloseOptions = IpcTimeoutOptions;
 
 export interface IpcBusBrokerPrivate {
     addHandler(message: IpcBusCommandKind, handler: () => void): void;
-    addClient(peer: IpcBusPeer, client: BrokerClient): void;
+    addClient(peers: IpcBusPeer[], client: BrokerClient): void;
 }
 
 export interface IpcBusBroker {

--- a/packages/universal/src/client/bus-client.ts
+++ b/packages/universal/src/client/bus-client.ts
@@ -33,7 +33,7 @@ export interface ClientConnectOptions extends IpcConnectOptions {
 export type IpcBusClientEmitter = ChannelEmitterLike<IpcBusListener>;
 
 export interface IpcBusClient extends IpcBusClientEmitter {
-    readonly peer: IpcBusPeer | undefined;
+    readonly peer: IpcBusPeer;
 
     connect: ConnectFunction<ClientConnectOptions>;
     close: CloseFunction<IpcTimeoutOptions>;

--- a/packages/universal/src/client/bus-connector.ts
+++ b/packages/universal/src/client/bus-connector.ts
@@ -2,7 +2,7 @@ import type { ClientCloseOptions, ClientConnectOptions } from './bus-client';
 import type { BusMessagePort } from './message-ports';
 import type { IpcBusCommand, IpcBusCommandBase } from '../contract/ipc-bus-command';
 import type { IpcBusMessage } from '../contract/ipc-bus-message';
-import type { IpcBusPeer } from '../contract/ipc-bus-peer';
+import type { IpcBusPeer, IpcBusProcessType } from '../contract/ipc-bus-peer';
 import type { QueryStateConnector } from '../contract/query-state';
 import type { ContractLogLevel } from '../log/ipc-bus-log-config';
 import type { IpcPacketBufferCore } from 'socket-serializer';
@@ -13,6 +13,7 @@ export interface ConnectorHandshake {
 }
 
 export interface IpcBusConnectorClient {
+    peers: IpcBusPeer[];
     onConnectorArgsReceived(
         ipcMessage: IpcBusMessage,
         args: unknown[],
@@ -52,14 +53,11 @@ export interface PostMessageFunction {
 }
 
 export interface IpcBusConnector {
-    readonly peer: IpcBusPeer;
+    readonly type: IpcBusProcessType;
 
-    isTarget(ipcMessage: IpcBusMessage): boolean;
-    queryState(): QueryStateConnector;
-
-    handshake(client: IpcBusConnectorClient, options: ClientConnectOptions): Promise<ConnectorHandshake>;
-    shutdown(options?: ClientCloseOptions): Promise<void>;
-
+    handshake(client: IpcBusConnectorClient, peer: IpcBusPeer, opts: ClientConnectOptions): Promise<ConnectorHandshake>;
+    shutdown(opts?: ClientCloseOptions): Promise<void>;
     postCommand(ipcCommand: IpcBusCommand): void;
     postMessage(ipcMessage: IpcBusMessage, args?: unknown[], messagePorts?: BusMessagePort[]): void;
+    queryState(): QueryStateConnector;
 }

--- a/packages/universal/src/client/bus-transport.ts
+++ b/packages/universal/src/client/bus-transport.ts
@@ -6,14 +6,14 @@ import type { IpcBusPeer } from '../contract/ipc-bus-peer';
 import type { QueryStateTransport } from '../contract/query-state';
 
 export interface IpcBusTransportClient {
-    peer?: IpcBusPeer;
+    peer: IpcBusPeer;
     listeners(eventName: string): Function[];
 }
 
 export interface IpcBusTransport {
     readonly connector: IpcBusConnector;
 
-    connect(client: IpcBusTransportClient, options: ClientConnectOptions): Promise<IpcBusPeer>;
+    connect(client: IpcBusTransportClient, options: ClientConnectOptions): Promise<void>;
     close(client: IpcBusTransportClient, options?: ClientCloseOptions): Promise<void>;
 
     createDirectChannel(client: IpcBusTransportClient): string;

--- a/packages/universal/src/contract/ipc-bus-command.ts
+++ b/packages/universal/src/contract/ipc-bus-command.ts
@@ -30,7 +30,16 @@ export interface IpcBusCommandBase {
     channel?: string;
 }
 
-export interface IpcBusCommand extends IpcBusCommandBase {
-    peer?: IpcBusPeer;
+interface IpcBusCommand1 extends IpcBusCommandBase {
+    peer?: never;
+    peers: IpcBusPeer[];
     channels?: string[];
 }
+
+interface IpcBusCommand2 extends IpcBusCommandBase {
+    peer: IpcBusPeer;
+    peers?: never;
+    channels?: string[];
+}
+
+export type IpcBusCommand = IpcBusCommand1 | IpcBusCommand2;

--- a/packages/universal/src/contract/query-state.ts
+++ b/packages/universal/src/contract/query-state.ts
@@ -54,7 +54,7 @@ export interface QueryStateConnector extends QueryStateBase {
         | 'connector-browser-ws'
         | 'connector-ws-local'
         | 'connector-main';
-    peer: IpcBusPeer;
+    id: string;
 }
 
 export interface QueryStateBroker extends Omit<QueryStateBase, 'peer'> {

--- a/packages/universal/test/client/bus-client.test.ts
+++ b/packages/universal/test/client/bus-client.test.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { EventEmitter } from 'events';
+import * as tsSinon from 'ts-sinon';
+
+import { IpcBusClientImpl, IpcBusCommandKind, IpcBusProcessType, IpcBusTransportMulti } from '../../src';
+
+import type { IpcBusClient, IpcBusConnector } from '../../src';
+
+describe('bus-client <=> multi-transport', () => {
+    let client: IpcBusClient;
+    let transport: IpcBusTransportMulti;
+    let connector: tsSinon.StubbedInstance<IpcBusConnector>;
+    const testChannel = 'test-channel';
+
+    beforeEach(async () => {
+        connector = tsSinon.stubInterface<IpcBusConnector>();
+        connector.handshake.resolves({ peer: { id: 'foo', type: IpcBusProcessType.Main } });
+        transport = new IpcBusTransportMulti(connector, () => 'uuid');
+        client = new IpcBusClientImpl(() => 'client-1-id', new EventEmitter(), transport);
+        await client.connect();
+    });
+
+    it('should emit event to all consumers when multiple listeners involved', () => {
+        let calledInFirst = false;
+        client.addListener(testChannel, () => {
+            calledInFirst = true;
+        });
+
+        let calledInSecond = false;
+        client.addListener(testChannel, () => {
+            calledInSecond = true;
+        });
+
+        transport.onConnectorArgsReceived({
+            channel: testChannel,
+            kind: IpcBusCommandKind.SendMessage,
+            peer: { id: 'bar', type: IpcBusProcessType.Renderer },
+        }, ['a', 'b', 'c']);
+        expect(calledInFirst).to.be.true;
+        expect(calledInSecond).to.be.true;
+    });
+
+    it('should emit event to only for first consumer if second unsubscribed', () => {
+        let calledInFirst = false;
+        const callback = () => {
+            calledInFirst = true;
+        };
+        client.addListener(testChannel, callback);
+
+        let calledInSecond = false;
+        client.addListener(testChannel, () => {
+            calledInSecond = true;
+        });
+
+        client.removeListener(testChannel, callback);
+        transport.onConnectorArgsReceived({
+            channel: testChannel,
+            kind: IpcBusCommandKind.SendMessage,
+            peer: { id: 'bar', type: IpcBusProcessType.Renderer },
+        }, ['a', 'b', 'c']);
+        expect(calledInFirst).to.be.false;
+        expect(calledInSecond).to.be.true;
+    });
+
+    it('should emit event to all consumers if more then one client is subscribed', () => {
+        const client2 = new IpcBusClientImpl(() => 'client-2-id', new EventEmitter(), transport);
+
+        let calledInFirst = false;
+        client.addListener(testChannel, () => {
+            calledInFirst = true;
+        });
+
+        let calledInSecond = false;
+        client2.addListener(testChannel, () => {
+            calledInSecond = true;
+        });
+
+        transport.onConnectorArgsReceived({
+            channel: testChannel,
+            kind: IpcBusCommandKind.SendMessage,
+            peer: { id: 'bar', type: IpcBusProcessType.Renderer },
+        }, ['a', 'b', 'c']);
+        expect(calledInFirst).to.be.true;
+        expect(calledInSecond).to.be.true;
+    });
+});

--- a/packages/web-socket-browser/src/ws-browser-factory-thin.ts
+++ b/packages/web-socket-browser/src/ws-browser-factory-thin.ts
@@ -30,13 +30,13 @@ export function createWebSocketClient(ctx: ThinContext): IpcBusClient {
     let realTransport = ctx.container?.getSingleton<IpcBusTransport>(BrowserTransportToken);
     if (!realTransport) {
         const connector = new WsBrowserConnector(ctx.uuidProvider, ctx.json, IpcBusProcessType.Browser, ctx.logger);
-        realTransport = new IpcBusTransportMulti(connector, ctx.uuidProvider);
+        realTransport = new IpcBusTransportMulti(connector, ctx.uuidProvider, ctx.messageStamp, ctx.logger);
         ctx.container?.registerSingleton(BrowserTransportToken, realTransport);
     }
 
     if (ctx.reconnect) {
-        return new WsBrowserBusClient(ctx.emitter, realTransport, ctx.logger, ctx.reconnect);
+        return new WsBrowserBusClient(ctx.uuidProvider, ctx.emitter, realTransport, ctx.logger, ctx.reconnect);
     }
 
-    return new IpcBusClientImpl(ctx.emitter, realTransport);
+    return new IpcBusClientImpl(ctx.uuidProvider, ctx.emitter, realTransport);
 }

--- a/packages/web-socket/src/broker/broker-factory-thin.ts
+++ b/packages/web-socket/src/broker/broker-factory-thin.ts
@@ -4,7 +4,7 @@ import { WsBrokerServerFactory } from './ws-broker-server-factory';
 import { BrokerToken, TransportToken } from '../constants';
 
 import type { WsConnectorLocal } from '../client/ws-connector-local';
-import type { BusContainer, IpcBusBroker, Logger, IpcBusTransport, JsonLike } from '@electron-common-ipc/universal';
+import type { BusContainer, IpcBusBroker, Logger, JsonLike, IpcBusTransportImpl } from '@electron-common-ipc/universal';
 
 export interface ThinContext {
     json: JsonLike;
@@ -28,11 +28,11 @@ export function createWebSocketBroker(ctx: ThinContext): IpcBusBroker {
     const broker = new BrokerImpl(serverFactory, IpcBusProcessType.Node, ctx.logger);
     ctx.container?.registerSingleton(BrokerToken, broker);
 
-    const maybeTransport = ctx.container?.getSingleton<IpcBusTransport>(TransportToken);
+    const maybeTransport = ctx.container?.getSingleton<IpcBusTransportImpl>(TransportToken);
     if (maybeTransport) {
         const maybeLocal = maybeTransport.connector as WsConnectorLocal;
         if (maybeLocal.subscribe && maybeLocal.release && maybeLocal.send) {
-            broker.addClient(maybeLocal.peer, maybeLocal);
+            broker.addClient(maybeTransport.peers, maybeLocal);
         }
     }
 


### PR DESCRIPTION
- improve how peers and peer ids are used
- use the peer collection on the transport side to handle multiple clients
- add peer and peers as required for the command to handle some cases with multiple client more efficiently
- add integration tests on the client <=> multi-transport
- make the client requirements more strict(in some places mocks are provided)