### PR TITLE
Fix the issue when emitter splits

### DIFF
--- a/packages/ipc-bus/src/service/IpcBusService-factory.ts
+++ b/packages/ipc-bus/src/service/IpcBusService-factory.ts
@@ -9,23 +9,26 @@ import type {
     IpcBusServiceProxy,
     ServiceProxyConnectOptions,
     BusServiceOptions,
+    ServiceEventEmitter,
 } from '@electron-common-ipc/universal';
 
 export function newIpcBusService(
     client: IpcBusClient,
     serviceName: string,
     serviceImpl: unknown,
-    options?: BusServiceOptions
+    options?: BusServiceOptions,
+    proto?: ServiceEventEmitter
 ): IpcBusService {
     const logger = Logger.service ? new ConsoleLogger() : undefined;
-    return createIpcBusService(client, serviceName, serviceImpl, EventEmitter.prototype, logger, options);
+    return createIpcBusService(client, serviceName, serviceImpl, proto ?? EventEmitter.prototype, logger, options);
 }
 
 export function newIpcBusServiceProxy(
     client: IpcBusClient,
     serviceName: string,
-    options?: ServiceProxyConnectOptions
+    options?: ServiceProxyConnectOptions,
+    emitter?: ServiceEventEmitter
 ): IpcBusServiceProxy {
     const logger = Logger.service ? new ConsoleLogger() : undefined;
-    return createIpcBusServiceProxy(client, serviceName, new EventEmitter(), options, logger);
+    return createIpcBusServiceProxy(client, serviceName, emitter ?? new EventEmitter(), options, logger);
 }


### PR DESCRIPTION
- the case with the 'events' poly, when inside off the 'removeListener' it can assign the '_events' property of the wrapper, breaking the prototype synchronization.
- fix the issue with the proxy, when constructor options were not used.
- tests on the service proxy
- extend the API to set the service emitter in the ipc-bus package.